### PR TITLE
Add permissions to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,3 +8,7 @@ commands:
     description: Open a LongUI GUI at client.
     permission: lui.use
     aliases: [luiopen,lopen]
+ permissions:
+   lui.use:
+     description: The permission used to open a GUI for a player.
+     default: op


### PR DESCRIPTION
added permission to the plugin.yml so that the permission will be automatically added to the permissions.yml without manually adding or adding with a permission plugin such as GM. I think that it should be recommended to have the server manage the permissions through the plugin.yml rather than use PluginManager#addPermission method for the simple reason that plugins may override a PermissionDefault and it is not clear whether permissions with the same name but different Defaults may be recognized by the PluginManager#getPermissions#contains method. So from my perspective it would be better to add a permissions label to your plugin.yml.